### PR TITLE
build(coverage): Generate lcov coverage report

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,6 +19,10 @@ module.exports = function (config) {
             reports: {
                 "clover": "coverage",
                 "html": "coverage",
+                "lcovonly": {
+                    "directory": "coverage",
+                    "filename": "lcov.info",
+                },
                 "json-summary": "coverage",
                 "json": "coverage",
                 "text": null


### PR DESCRIPTION
lcovonly will generate a lcov file which can be used on coverage.io to display code coverage